### PR TITLE
fixes typo in json tag for VoiceServer

### DIFF
--- a/voiceServer/voiceServer.go
+++ b/voiceServer/voiceServer.go
@@ -7,5 +7,5 @@ type VoiceServer struct {
 	Description        string `json:"description"`
 	CountryId          string `json:"countryId"`
 	CurrentConnections int64  `json:"currentConnections"`
-	MaximumConnections int64  `json:"MaximumConnections"`
+	MaximumConnections int64  `json:"maximumConnections"`
 }


### PR DESCRIPTION
changes the VoiceServer struct json tag "MaximumConnections" to "maximumConnections" to match the tag in whazzup-json